### PR TITLE
#4: Fix naming conventions on containers

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Construct Docker image name
+        run: |
+          IMAGE_NAME=$(echo ${{ matrix.config.dockerfile }} | sed -E 's/^([^-]+)-([^-]+)/\1-\2${{ matrix.config.compiler-version }}/')
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
+
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
         with:
@@ -54,9 +59,10 @@ jobs:
       - name: Build and Push Docker images for Github Container Registry
         uses: docker/build-push-action@v6
         with:
-          tags: ghcr.io/pressio/${{ matrix.config.dockerfile }}-${{ matrix.config.compiler-version }}:${{ matrix.config.tag }}
+          tags: ghcr.io/pressio/${{ env.IMAGE_NAME }}:${{ matrix.config.tag }}
           file: docker_scripts/${{ matrix.config.dockerfile }}.dockerfile
           build-args: |
             COMPILER_VERSION=${{ matrix.config.compiler-version }}
             DOCKER_TAG=${{ matrix.config.tag }}
-          push: true
+          # Only push image if running on main or develop
+          push: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}


### PR DESCRIPTION
Fixes #4 

Moves compiler version to immediately follow the compiler. For example:

- `ubuntu-clang14`
- `ubuntu-gnu11-kokkos-cpu-openmp`
- `fedora-clang17-mpi`

Also updates pipelines to only push images on merges to `main` or `develop`. (Images will **build** in CI, but only push to the container registry when the PR is merged.)